### PR TITLE
fix(checkbox): add solid-icons dependency

### DIFF
--- a/apps/www/src/registry/registry.ts
+++ b/apps/www/src/registry/registry.ts
@@ -39,7 +39,7 @@ const ui: Registry = [
 	{
 		name: "checkbox",
 		type: "components:ui",
-		dependencies: ["@kobalte/core"],
+		dependencies: ["@kobalte/core", "solid-icons"],
 		files: ["ui/checkbox.tsx"],
 	},
 	{


### PR DESCRIPTION
The `solid-icons` package used for the checkbox wasn't being installed - I think this the right place to add it?
