### PR TITLE
docs: use TextField instead of TextFieldRoot

### DIFF
--- a/apps/www/src/routes/docs/components/textarea.mdx
+++ b/apps/www/src/routes/docs/components/textarea.mdx
@@ -53,13 +53,13 @@ npm install @kobalte/core
 
 ```tsx
 import { TextFieldTextArea } from "@/components/ui/textarea"
-import { TextFieldRoot } from "@/components/ui/textfield"
+import { TextField } from "@/components/ui/textfield"
 ```
 
 ```tsx
-<TextFieldRoot>
+<TextField>
     <TextFieldTextArea />
-</TextFieldRoot>
+</TextField>
 ```
 
 ## Examples

--- a/apps/www/src/routes/docs/components/textfield.mdx
+++ b/apps/www/src/routes/docs/components/textfield.mdx
@@ -52,13 +52,13 @@ npm install @kobalte/core
 ## Usage
 
 ```tsx
-import { TextFieldRoot, TextFieldInput } from "@/components/ui/textfield"
+import { TextField, TextFieldInput } from "@/components/ui/textfield"
 ```
 
 ```tsx
-<TextFieldRoot>
+<TextField>
     <TextFieldInput type="email" placeholder="Email" />
-</TextFieldRoot>
+</TextField>
 ```
 
 ## Examples


### PR DESCRIPTION
There isn't a `TextFieldRoot` export, but Kobalte's `TextFieldPrimitive.Root` is exported as `TextField` and I assume the `Root` bit got carried over accidentally.