### PR TITLE
docs: change installation command for first component

### DIFF
--- a/apps/www/src/contents/docs/installation/astro.mdx
+++ b/apps/www/src/contents/docs/installation/astro.mdx
@@ -192,7 +192,7 @@ export default {
 You can now start adding components to your project.
 
 ```bash
-npx shadcn-ui@latest add button
+npx shadcn-solid@latest add button
 ```
 
 You can then import shadcn componets in Astro like this:

--- a/apps/www/src/contents/docs/installation/manual.mdx
+++ b/apps/www/src/contents/docs/installation/manual.mdx
@@ -399,7 +399,7 @@ export const cn = (...classLists: ClassValue[]) => twMerge(clsx(classLists));
 You can now start adding components to your project.
 
 ```bash
-npx shadcn-ui@latest add button
+npx shadcn-solid@latest add button
 ```
 
 The command above will add the Button component to your project. You can then import it like this:

--- a/apps/www/src/contents/docs/installation/solid-start.mdx
+++ b/apps/www/src/contents/docs/installation/solid-start.mdx
@@ -93,7 +93,7 @@ You will be asked a few questions to configure `components.json`:
 You can now start adding components to your project.
 
 ```bash
-npx shadcn-ui@latest add button
+npx shadcn-solid@latest add button
 ```
 
 The command above will add the Button component to your project. You can then import it like this:


### PR DESCRIPTION
In the Installation documentation, when the user should run the command to install the first component (button component), the command would fail, since it is referencing the shadcn-ui library instead of the shadcn-solid library.