### PR TITLE
docs: fix typo in textarea.mdx

### DIFF
--- a/apps/www/src/contents/docs/components/textarea.mdx
+++ b/apps/www/src/contents/docs/components/textarea.mdx
@@ -57,9 +57,9 @@ import { TextFieldRoot } from "@/components/ui/textfield";
 ```
 
 ```tsx
-<TextFieldRot>
+<TextFieldRoot>
   <TextArea />
-</TextFieldRot>
+</TextFieldRoot>
 ```
 
 ## Examples


### PR DESCRIPTION
When copying the Usage-Example, the typo results in an error of the component.