### PR TITLE
fix: page transition jank and typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Accessible and customizable components that you can copy and paste into your app
 
 ## Documentation
 
-Visit https://shadcn-solid.com/docs to view the documentation.
+Visit our [documentation](https://shadcn-solid.com/docs/introduction) to learn more.
 
 ## License
 

--- a/docs/src/content/docs/components/collapsible.mdx
+++ b/docs/src/content/docs/components/collapsible.mdx
@@ -22,7 +22,7 @@ import UnoRawCode from "@repo/unocss/ui/collapsible?raw";
 
 <Fragment slot="cli">
 ```bash
-npx shadcn-solid@latest add alert-dialog
+npx shadcn-solid@latest add collapsible
 ```
 </Fragment>
 

--- a/docs/src/layouts/root-layout.astro
+++ b/docs/src/layouts/root-layout.astro
@@ -1,4 +1,5 @@
 ---
+import { ViewTransitions } from "astro:transitions";
 import Footer from "@/components/footer.astro";
 import Header from "@/components/header.astro";
 import ToastWrapper from "@/components/toast-wrapper";
@@ -99,6 +100,8 @@ const { title, description, url } = Astro.props;
                 font-display: swap;
             }
         </style>
+
+        <ViewTransitions />
     </head>
     <body>
         <div class="relative flex min-h-screen flex-col">


### PR DESCRIPTION
Should be mostly self-explanatory but happy to provide more context.

The astro ViewTransition avoids the layout janking when going between documentation pages.