### PR TITLE
fix: update schema URL in components.json

### DIFF
--- a/docs/src/data/docs/components-json.mdx
+++ b/docs/src/data/docs/components-json.mdx
@@ -25,7 +25,7 @@ You can see the JSON Schema for `components.json` [here](https://shadcn-solid.ve
 
 ```json title="components.json"
 {
-  "$schema": "https:/shadcn-solid.vercel.app/schema.json"
+  "$schema": "https:/shadcn-solid.com/schema.json"
 }
 ```
 


### PR DESCRIPTION
Replaced the outdated URL (shadcn-solid.vercel.app) with the correct one (shadcn-solid.com). This resolves potential schema reference issues in the components.json file.