### PR TITLE
Fix file paths in installation documentation

### DIFF
--- a/apps/docs/src/content/docs/installation.mdx
+++ b/apps/docs/src/content/docs/installation.mdx
@@ -270,7 +270,7 @@ Copy and paste the following code into your project.
 
 <ComponentSource data-slot='installation'>
 
-```tsx title="src/lib/cva" file=<rootDir>/apps/docs/src/registry/lib/cva.ts
+```tsx title="src/lib/cva.ts" file=<rootDir>/apps/docs/src/registry/lib/cva.ts
 
 ```
 
@@ -278,7 +278,7 @@ Copy and paste the following code into your project.
 
 <ComponentSource data-slot='installation'>
 
-```tsx title="src/lib/call-handler" file=<rootDir>/apps/docs/src/registry/lib/call-handler.ts
+```tsx title="src/lib/call-handler.ts" file=<rootDir>/apps/docs/src/registry/lib/call-handler.ts
 
 ```
 
@@ -286,7 +286,7 @@ Copy and paste the following code into your project.
 
 <ComponentSource data-slot='installation'>
 
-```tsx title="src/lib/combine-style" file=<rootDir>/apps/docs/src/registry/lib/combine-style.ts
+```tsx title="src/lib/combine-style.ts" file=<rootDir>/apps/docs/src/registry/lib/combine-style.ts
 
 ```
 
@@ -294,7 +294,7 @@ Copy and paste the following code into your project.
 
 <ComponentSource data-slot='installation'>
 
-```tsx title="src/hooks/use-mobile" file=<rootDir>/apps/docs/src/registry/hooks/use-mobile.ts
+```tsx title="src/hooks/use-mobile.ts" file=<rootDir>/apps/docs/src/registry/hooks/use-mobile.ts
 
 ```
 


### PR DESCRIPTION
When going through installation, I noticed the file extension was missing on the titles for each code snippet