### PR TITLE
feat(cards): implement copy to clipboard for share card

### DIFF
--- a/apps/docs/src/components/cards/share.tsx
+++ b/apps/docs/src/components/cards/share.tsx
@@ -23,6 +23,7 @@ import {
   TextFieldInput,
   TextFieldLabel,
 } from "@/registry/ui/text-field"
+import { toast } from "somoto"
 
 const people = [
   {
@@ -43,6 +44,16 @@ const people = [
 ]
 
 const CardsShare = () => {
+  const handleCopy = () => {
+    void navigator.clipboard
+      .writeText("http://example.com/link/to/document")
+      .then(() => {
+        toast.success("Link copied successfully!")
+      })
+      .catch(() => {
+        toast.error("Failed to copy link!")
+      })
+  }
   return (
     <Card>
       <CardHeader>
@@ -59,7 +70,12 @@ const CardsShare = () => {
             class="h-8 w-full"
             readOnly
           />
-          <Button size="sm" variant="outline" class="shadow-none">
+          <Button
+            size="sm"
+            variant="outline"
+            class="shadow-none"
+            onClick={handleCopy}
+          >
             Copy Link
           </Button>
         </TextField>


### PR DESCRIPTION
## Summary
Implements working copy-to-clipboard functionality for the share card component. Previously, the copy button existed but didn't actually copy the link.

## Changes
- Add `handleCopy` function using `navigator.clipboard` API
- Import `toast` from somoto for user feedback notifications
- Connect `onClick` handler to the copy button
- Display success/error toast messages for user feedback
- Follow SolidJS reactive patterns with `void` + promise chain (consistent with `copy-button.tsx`)

## Motivation
The share card displayed a "Copy Link" button but clicking it performed no action. This PR adds the actual clipboard functionality and provides user feedback through toast notifications.

## Testing
- ✅ Click copy button successfully copies link to clipboard
- ✅ Success toast displays on successful copy
- ✅ Error toast displays if clipboard access fails